### PR TITLE
Make integration tests not use index types

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ This plugin is based on [Prometheus exporter for Elasticsearch](https://github.c
 
 ## Compatibility matrix
 
-| OpenSearch | Plugin   | Release date    |
-|------------|----------|-----------------|
-| 1.2.3      | 1.2.3.0  | TBD |
+|  OpenSearch |   Plugin |  Release date |
+|------------:|---------:|--------------:|
+|       1.2.3 |  1.2.3.0 |           TBD |
 
 ## Install
 
@@ -113,7 +113,7 @@ Just keep in mind that `metrics_path` must be `/_prometheus/metrics`, otherwise 
 
 ## Testing
 
-Project contains [integration tests](src/test/resources/rest-api-spec) implemented using
+Project contains [integration tests](src/yamlRestTest/resources/rest-api-spec) implemented using
 [rest layer](https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md#testing-the-rest-layer)
 framework.
 
@@ -125,8 +125,7 @@ Complete test suite is run using:
 To run individual integration rest test file use:
 ```
 ./gradlew :yamlRestTest \
-  -Dtests.class=org.opensearch.plugin.prometheus.PrometheusRestHandlerClientYamlTestSuiteIT \
-  -Dtests.method="test {yaml=test/20_metrics/Prometheus metrics can be pulled}"
+  -Dtests.method="test {yaml=/20_11_index_level_metrics_disabled/Dynamically disable index level metrics}"
 ```
 
 ## Credits

--- a/src/yamlRestTest/resources/rest-api-spec/test/20_11_index_level_metrics_disabled.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/20_11_index_level_metrics_disabled.yml
@@ -21,7 +21,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_00_index_level_info.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_00_index_level_info.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 
@@ -77,7 +76,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_10_index_indexing.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_10_index_indexing.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_11_index_get.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_11_index_get.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_12_index_search.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_12_index_search.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_13_index_merges.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_13_index_merges.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_14_index_refresh.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_14_index_refresh.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_15_index_flush.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_15_index_flush.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_16_index_querycache.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_16_index_querycache.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_17_index_fieldata.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_17_index_fieldata.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_18_index_completion.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_18_index_completion.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_19_index_segments.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_19_index_segments.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_20_index_suggest.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_20_index_suggest.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_21_index_requestcache.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_21_index_requestcache.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_22_index_recovery.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_22_index_recovery.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_23_index_translog.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_23_index_translog.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_24_index_warmer.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_24_index_warmer.yml
@@ -14,7 +14,6 @@
   - do:
       index:
         index:  twitter
-        type:   foo
         id:     1
         body:   { foo: bar }
 


### PR DESCRIPTION
- Remove use of index types in tests (it was yielding deprecation warning)
- Fix instructions about running individual IT tests

Closes #1
Closes #3

Signed-off-by: lukas-vlcek <lukas.vlcek@aiven.io>