### PR TITLE
Make the metric name prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,42 @@ Start OpenSearch cluster.
 
 ## Plugin configuration
 
-If you have a lot of indices and think this data is irrelevant, you can disable in the main configuration file:
+### Static settings
+
+#### Metric name prefix
+
+All metric names share common prefix, by default set to `opensearch_`.
+
+The value of this prefix can be customized using setting:
+```
+prometheus.metric_name.prefix: "opensearch_"
+```
+
+### Dynamic settings
+
+#### Index level metrics
+
+Detailed index level metrics can represent a lot of data and can lead to high-cardinality labels in Prometheus.
+If you do not need detailed index level metrics it is recommended to disable it via setting:
 
 ```
 prometheus.indices: false
 ```
+
+#### Cluster settings
 
 To disable exporting cluster settings use:
 ```
 prometheus.cluster.settings: false
 ```
 
-These settings can be also [updated dynamically](https://opensearch.org/docs/latest/opensearch/configuration/#update-cluster-settings-using-the-api).
+Both these settings can be [updated dynamically](https://opensearch.org/docs/latest/opensearch/configuration/#update-cluster-settings-using-the-api).
 
 ## Uninstall
 
 You need to remove the plugin from all nodes where it was installed.
 
-`./bin/elasticsearch-plugin remove prometheus-exporter`
+`./bin/opensearch-plugin remove prometheus-exporter`
 
 Do not forget to restart the node after installation.
 
@@ -68,24 +86,24 @@ Metrics are directly available at:
 As a sample result, you get:
 
 ```
-# HELP es_process_mem_total_virtual_bytes Memory used by ES process
-# TYPE es_process_mem_total_virtual_bytes gauge
+# HELP opensearch_process_mem_total_virtual_bytes Memory used by ES process
+# TYPE opensearch_process_mem_total_virtual_bytes gauge
 es_process_mem_total_virtual_bytes{cluster="develop",node="develop01",} 3.626733568E9
-# HELP es_indices_indexing_is_throttled_bool Is indexing throttling ?
-# TYPE es_indices_indexing_is_throttled_bool gauge
+# HELP opensearch_indices_indexing_is_throttled_bool Is indexing throttling ?
+# TYPE opensearch_indices_indexing_is_throttled_bool gauge
 es_indices_indexing_is_throttled_bool{cluster="develop",node="develop01",} 0.0
-# HELP es_jvm_gc_collection_time_seconds Time spent for GC collections
-# TYPE es_jvm_gc_collection_time_seconds counter
+# HELP opensearch_jvm_gc_collection_time_seconds Time spent for GC collections
+# TYPE opensearch_jvm_gc_collection_time_seconds counter
 es_jvm_gc_collection_time_seconds{cluster="develop",node="develop01",gc="old",} 0.0
 es_jvm_gc_collection_time_seconds{cluster="develop",node="develop01",gc="young",} 0.0
-# HELP es_indices_requestcache_memory_size_bytes Memory used for request cache
-# TYPE es_indices_requestcache_memory_size_bytes gauge
+# HELP opensearch_indices_requestcache_memory_size_bytes Memory used for request cache
+# TYPE opensearch_indices_requestcache_memory_size_bytes gauge
 es_indices_requestcache_memory_size_bytes{cluster="develop",node="develop01",} 0.0
-# HELP es_indices_search_open_contexts_number Number of search open contexts
-# TYPE es_indices_search_open_contexts_number gauge
+# HELP opensearch_indices_search_open_contexts_number Number of search open contexts
+# TYPE opensearch_indices_search_open_contexts_number gauge
 es_indices_search_open_contexts_number{cluster="develop",node="develop01",} 0.0
-# HELP es_jvm_mem_nonheap_used_bytes Memory used apart from heap
-# TYPE es_jvm_mem_nonheap_used_bytes gauge
+# HELP opensearch_jvm_mem_nonheap_used_bytes Memory used apart from heap
+# TYPE opensearch_jvm_mem_nonheap_used_bytes gauge
 es_jvm_mem_nonheap_used_bytes{cluster="develop",node="develop01",} 5.5302736E7
 ...
 ```

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
@@ -25,7 +25,7 @@ import org.opensearch.common.settings.Settings;
  * A container to keep settings for prometheus up to date with cluster setting changes.
  *
  * In order to make the settings dynamically updatable we took some inspiration from implementation
- * and use of DiskThresholdSettings class in Elasticsearch.
+ * and use of DiskThresholdSettings class in OpenSearch.
  */
 public class PrometheusSettings {
 

--- a/src/main/java/org/opensearch/plugin/prometheus/PrometheusExporterPlugin.java
+++ b/src/main/java/org/opensearch/plugin/prometheus/PrometheusExporterPlugin.java
@@ -71,7 +71,8 @@ public class PrometheusExporterPlugin extends Plugin implements ActionPlugin {
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = Arrays.asList(
                 PrometheusSettings.PROMETHEUS_CLUSTER_SETTINGS,
-                PrometheusSettings.PROMETHEUS_INDICES
+                PrometheusSettings.PROMETHEUS_INDICES,
+                RestPrometheusMetricsAction.METRIC_PREFIX
         );
         return Collections.unmodifiableList(settings);
     }

--- a/src/yamlRestTest/resources/rest-api-spec/test/20_00_metrics.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/20_00_metrics.yml
@@ -17,10 +17,10 @@
 
   - match:
       $body: |
-               /.* es_indices_segments_memory_bytes .*/
+               /.* opensearch_indices_segments_memory_bytes .*/
 
   - match:
-      $body: /# HELP es_os_swap_total_bytes Total swap size\n# TYPE es_os_swap_total_bytes gauge\n.*/
+      $body: /# HELP opensearch_os_swap_total_bytes Total swap size\n# TYPE opensearch_os_swap_total_bytes gauge\n.*/
 
 
 #---

--- a/src/yamlRestTest/resources/rest-api-spec/test/20_10_cluster_settings_metrics_disabled.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/20_10_cluster_settings_metrics_disabled.yml
@@ -21,9 +21,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
-        es_cluster_routing_allocation_disk_threshold_enabled\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_disk_threshold_enabled\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/
@@ -54,8 +54,8 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
@@ -65,8 +65,8 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
@@ -94,8 +94,8 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
@@ -123,8 +123,8 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
@@ -150,9 +150,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
-        es_cluster_routing_allocation_disk_threshold_enabled\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_disk_threshold_enabled\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_00_index_level_info.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_00_index_level_info.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_shards_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_shards_number \s gauge \n
+        \# \s HELP \s opensearch_index_shards_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_shards_number \s gauge \n
         (
-          es_index_shards_number\{
+          opensearch_index_shards_number\{
               cluster="yamlRestTest",
               type="(active_primary|initializing|relocating|shards|active|unassigned)",
               index="twitter"
@@ -43,9 +43,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_status (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_status \s gauge \n
-        es_index_status\{
+        \# \s HELP \s opensearch_index_status (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_status \s gauge \n
+        opensearch_index_status\{
             cluster="yamlRestTest",index="twitter"
         \,} \s \d+\.\d+ \n?
         .*/
@@ -53,9 +53,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_replicas_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_replicas_number \s gauge \n
-        es_index_replicas_number\{
+        \# \s HELP \s opensearch_index_replicas_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_replicas_number \s gauge \n
+        opensearch_index_replicas_number\{
             cluster="yamlRestTest",index="twitter"
         ,\} \s+ \d+\.\d+ \n?
         .*/
@@ -91,10 +91,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_doc_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_doc_number \s gauge \n
+        \# \s HELP \s opensearch_index_doc_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_doc_number \s gauge \n
         (
-          es_index_doc_number\{
+          opensearch_index_doc_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -103,10 +103,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_doc_deleted_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_doc_deleted_number \s gauge \n
+        \# \s HELP \s opensearch_index_doc_deleted_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_doc_deleted_number \s gauge \n
         (
-          es_index_doc_deleted_number\{
+          opensearch_index_doc_deleted_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -115,10 +115,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_store_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_store_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_store_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_store_size_bytes \s gauge \n
         (
-          es_index_store_size_bytes\{
+          opensearch_index_store_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_10_index_indexing.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_10_index_indexing.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_delete_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_delete_count \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_delete_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_delete_count \s gauge \n
         (
-          es_index_indexing_delete_count\{
+          opensearch_index_indexing_delete_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_delete_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_delete_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_delete_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_delete_current_number \s gauge \n
         (
-          es_index_indexing_delete_current_number\{
+          opensearch_index_indexing_delete_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_delete_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_delete_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_delete_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_delete_time_seconds \s gauge \n
         (
-          es_index_indexing_delete_time_seconds\{
+          opensearch_index_indexing_delete_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -65,10 +65,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_index_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_index_count \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_index_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_index_count \s gauge \n
         (
-          es_index_indexing_index_count\{
+          opensearch_index_indexing_index_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -77,10 +77,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_index_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_index_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_index_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_index_current_number \s gauge \n
         (
-          es_index_indexing_index_current_number\{
+          opensearch_index_indexing_index_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -89,10 +89,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_index_failed_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_index_failed_count \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_index_failed_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_index_failed_count \s gauge \n
         (
-          es_index_indexing_index_failed_count\{
+          opensearch_index_indexing_index_failed_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -101,10 +101,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_index_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_index_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_index_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_index_time_seconds \s gauge \n
         (
-          es_index_indexing_index_time_seconds\{
+          opensearch_index_indexing_index_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -113,10 +113,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_noop_update_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_noop_update_count \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_noop_update_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_noop_update_count \s gauge \n
         (
-          es_index_indexing_noop_update_count\{
+          opensearch_index_indexing_noop_update_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -125,10 +125,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_is_throttled_bool (\s|\w|\d)+ \? \n
-        \# \s TYPE \s es_index_indexing_is_throttled_bool \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_is_throttled_bool (\s|\w|\d)+ \? \n
+        \# \s TYPE \s opensearch_index_indexing_is_throttled_bool \s gauge \n
         (
-          es_index_indexing_is_throttled_bool\{
+          opensearch_index_indexing_is_throttled_bool\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -137,10 +137,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_indexing_throttle_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_indexing_throttle_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_indexing_throttle_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_indexing_throttle_time_seconds \s gauge \n
         (
-          es_index_indexing_throttle_time_seconds\{
+          opensearch_index_indexing_throttle_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_11_index_get.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_11_index_get.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_get_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_get_count \s gauge \n
+        \# \s HELP \s opensearch_index_get_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_get_count \s gauge \n
         (
-          es_index_get_count\{
+          opensearch_index_get_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_get_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_get_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_get_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_get_time_seconds \s gauge \n
         (
-          es_index_get_time_seconds\{
+          opensearch_index_get_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_get_exists_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_get_exists_count \s gauge \n
+        \# \s HELP \s opensearch_index_get_exists_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_get_exists_count \s gauge \n
         (
-          es_index_get_exists_count\{
+          opensearch_index_get_exists_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -65,10 +65,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_get_exists_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_get_exists_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_get_exists_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_get_exists_time_seconds \s gauge \n
         (
-          es_index_get_exists_time_seconds\{
+          opensearch_index_get_exists_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -77,10 +77,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_get_missing_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_get_missing_count \s gauge \n
+        \# \s HELP \s opensearch_index_get_missing_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_get_missing_count \s gauge \n
         (
-          es_index_get_missing_count\{
+          opensearch_index_get_missing_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -89,10 +89,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_get_missing_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_get_missing_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_get_missing_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_get_missing_time_seconds \s gauge \n
         (
-          es_index_get_missing_time_seconds\{
+          opensearch_index_get_missing_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -101,10 +101,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_get_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_get_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_get_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_get_current_number \s gauge \n
         (
-          es_index_get_current_number\{
+          opensearch_index_get_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_12_index_search.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_12_index_search.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_open_contexts_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_open_contexts_number \s gauge \n
+        \# \s HELP \s opensearch_index_search_open_contexts_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_open_contexts_number \s gauge \n
         (
-          es_index_search_open_contexts_number\{
+          opensearch_index_search_open_contexts_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_fetch_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_fetch_count \s gauge \n
+        \# \s HELP \s opensearch_index_search_fetch_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_fetch_count \s gauge \n
         (
-          es_index_search_fetch_count\{
+          opensearch_index_search_fetch_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_fetch_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_fetch_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_search_fetch_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_fetch_current_number \s gauge \n
         (
-          es_index_search_fetch_current_number\{
+          opensearch_index_search_fetch_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -65,10 +65,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_fetch_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_fetch_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_search_fetch_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_fetch_time_seconds \s gauge \n
         (
-          es_index_search_fetch_time_seconds\{
+          opensearch_index_search_fetch_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -77,10 +77,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_query_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_query_count \s gauge \n
+        \# \s HELP \s opensearch_index_search_query_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_query_count \s gauge \n
         (
-          es_index_search_query_count\{
+          opensearch_index_search_query_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -89,10 +89,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_query_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_query_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_search_query_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_query_current_number \s gauge \n
         (
-          es_index_search_query_current_number\{
+          opensearch_index_search_query_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -101,10 +101,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_query_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_query_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_search_query_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_query_time_seconds \s gauge \n
         (
-          es_index_search_query_time_seconds\{
+          opensearch_index_search_query_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -113,10 +113,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_scroll_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_scroll_count \s gauge \n
+        \# \s HELP \s opensearch_index_search_scroll_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_scroll_count \s gauge \n
         (
-          es_index_search_scroll_count\{
+          opensearch_index_search_scroll_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -125,10 +125,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_scroll_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_scroll_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_search_scroll_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_scroll_current_number \s gauge \n
         (
-          es_index_search_scroll_current_number\{
+          opensearch_index_search_scroll_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -137,10 +137,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_search_scroll_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_search_scroll_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_search_scroll_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_search_scroll_time_seconds \s gauge \n
         (
-          es_index_search_scroll_time_seconds\{
+          opensearch_index_search_scroll_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_13_index_merges.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_13_index_merges.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_merges_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_current_number \s gauge \n
         (
-          es_index_merges_current_number\{
+          opensearch_index_merges_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_current_docs_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_current_docs_number \s gauge \n
+        \# \s HELP \s opensearch_index_merges_current_docs_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_current_docs_number \s gauge \n
         (
-          es_index_merges_current_docs_number\{
+          opensearch_index_merges_current_docs_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_current_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_current_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_merges_current_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_current_size_bytes \s gauge \n
         (
-          es_index_merges_current_size_bytes\{
+          opensearch_index_merges_current_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -65,10 +65,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_total_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_total_number \s gauge \n
+        \# \s HELP \s opensearch_index_merges_total_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_total_number \s gauge \n
         (
-          es_index_merges_total_number\{
+          opensearch_index_merges_total_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -77,10 +77,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_total_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_total_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_merges_total_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_total_time_seconds \s gauge \n
         (
-          es_index_merges_total_time_seconds\{
+          opensearch_index_merges_total_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -89,10 +89,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_total_docs_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_total_docs_count \s gauge \n
+        \# \s HELP \s opensearch_index_merges_total_docs_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_total_docs_count \s gauge \n
         (
-          es_index_merges_total_docs_count\{
+          opensearch_index_merges_total_docs_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -101,10 +101,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_total_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_total_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_merges_total_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_total_size_bytes \s gauge \n
         (
-          es_index_merges_total_size_bytes\{
+          opensearch_index_merges_total_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -113,10 +113,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_total_stopped_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_total_stopped_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_merges_total_stopped_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_total_stopped_time_seconds \s gauge \n
         (
-          es_index_merges_total_stopped_time_seconds\{
+          opensearch_index_merges_total_stopped_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -125,10 +125,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_total_throttled_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_total_throttled_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_merges_total_throttled_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_total_throttled_time_seconds \s gauge \n
         (
-          es_index_merges_total_throttled_time_seconds\{
+          opensearch_index_merges_total_throttled_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -137,10 +137,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_merges_total_auto_throttle_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_merges_total_auto_throttle_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_merges_total_auto_throttle_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_merges_total_auto_throttle_bytes \s gauge \n
         (
-          es_index_merges_total_auto_throttle_bytes\{
+          opensearch_index_merges_total_auto_throttle_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+([eE]\d+)? \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_14_index_refresh.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_14_index_refresh.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_refresh_total_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_refresh_total_count \s gauge \n
+        \# \s HELP \s opensearch_index_refresh_total_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_refresh_total_count \s gauge \n
         (
-          es_index_refresh_total_count\{
+          opensearch_index_refresh_total_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_refresh_total_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_refresh_total_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_refresh_total_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_refresh_total_time_seconds \s gauge \n
         (
-          es_index_refresh_total_time_seconds\{
+          opensearch_index_refresh_total_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_refresh_listeners_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_refresh_listeners_number \s gauge \n
+        \# \s HELP \s opensearch_index_refresh_listeners_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_refresh_listeners_number \s gauge \n
         (
-          es_index_refresh_listeners_number\{
+          opensearch_index_refresh_listeners_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_15_index_flush.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_15_index_flush.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_flush_total_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_flush_total_count \s gauge \n
+        \# \s HELP \s opensearch_index_flush_total_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_flush_total_count \s gauge \n
         (
-          es_index_flush_total_count\{
+          opensearch_index_flush_total_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_flush_total_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_flush_total_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_flush_total_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_flush_total_time_seconds \s gauge \n
         (
-          es_index_flush_total_time_seconds\{
+          opensearch_index_flush_total_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_16_index_querycache.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_16_index_querycache.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_querycache_cache_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_querycache_cache_count \s gauge \n
+        \# \s HELP \s opensearch_index_querycache_cache_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_querycache_cache_count \s gauge \n
         (
-          es_index_querycache_cache_count\{
+          opensearch_index_querycache_cache_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_querycache_cache_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_querycache_cache_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_querycache_cache_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_querycache_cache_size_bytes \s gauge \n
         (
-          es_index_querycache_cache_size_bytes\{
+          opensearch_index_querycache_cache_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_querycache_evictions_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_querycache_evictions_count \s gauge \n
+        \# \s HELP \s opensearch_index_querycache_evictions_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_querycache_evictions_count \s gauge \n
         (
-          es_index_querycache_evictions_count\{
+          opensearch_index_querycache_evictions_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -65,10 +65,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_querycache_hit_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_querycache_hit_count \s gauge \n
+        \# \s HELP \s opensearch_index_querycache_hit_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_querycache_hit_count \s gauge \n
         (
-          es_index_querycache_hit_count\{
+          opensearch_index_querycache_hit_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -77,10 +77,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_querycache_memory_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_querycache_memory_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_querycache_memory_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_querycache_memory_size_bytes \s gauge \n
         (
-          es_index_querycache_memory_size_bytes\{
+          opensearch_index_querycache_memory_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -89,10 +89,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_querycache_miss_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_querycache_miss_number \s gauge \n
+        \# \s HELP \s opensearch_index_querycache_miss_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_querycache_miss_number \s gauge \n
         (
-          es_index_querycache_miss_number\{
+          opensearch_index_querycache_miss_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -101,10 +101,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_querycache_total_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_querycache_total_number \s gauge \n
+        \# \s HELP \s opensearch_index_querycache_total_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_querycache_total_number \s gauge \n
         (
-          es_index_querycache_total_number\{
+          opensearch_index_querycache_total_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_17_index_fieldata.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_17_index_fieldata.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_fielddata_memory_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_fielddata_memory_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_fielddata_memory_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_fielddata_memory_size_bytes \s gauge \n
         (
-          es_index_fielddata_memory_size_bytes\{
+          opensearch_index_fielddata_memory_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_fielddata_evictions_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_fielddata_evictions_count \s gauge \n
+        \# \s HELP \s opensearch_index_fielddata_evictions_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_fielddata_evictions_count \s gauge \n
         (
-          es_index_fielddata_evictions_count\{
+          opensearch_index_fielddata_evictions_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_18_index_completion.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_18_index_completion.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_completion_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_completion_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_completion_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_completion_size_bytes \s gauge \n
         (
-          es_index_completion_size_bytes\{
+          opensearch_index_completion_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_19_index_segments.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_19_index_segments.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_segments_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_segments_number \s gauge \n
+        \# \s HELP \s opensearch_index_segments_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_segments_number \s gauge \n
         (
-          es_index_segments_number\{
+          opensearch_index_segments_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_segments_memory_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_segments_memory_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_segments_memory_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_segments_memory_bytes \s gauge \n
         (
-          es_index_segments_memory_bytes\{
+          opensearch_index_segments_memory_bytes\{
               cluster="yamlRestTest",type="(all|bitset|docvalues|indexwriter|norms|storefields|terms|termvectors|versionmap|points)",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){20}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_20_index_suggest.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_20_index_suggest.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_suggest_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_suggest_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_suggest_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_suggest_current_number \s gauge \n
         (
-          es_index_suggest_current_number\{
+          opensearch_index_suggest_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_suggest_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_suggest_count \s gauge \n
+        \# \s HELP \s opensearch_index_suggest_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_suggest_count \s gauge \n
         (
-          es_index_suggest_count\{
+          opensearch_index_suggest_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_suggest_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_suggest_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_suggest_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_suggest_time_seconds \s gauge \n
         (
-          es_index_suggest_time_seconds\{
+          opensearch_index_suggest_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_21_index_requestcache.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_21_index_requestcache.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_requestcache_memory_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_requestcache_memory_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_requestcache_memory_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_requestcache_memory_size_bytes \s gauge \n
         (
-          es_index_requestcache_memory_size_bytes\{
+          opensearch_index_requestcache_memory_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_requestcache_hit_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_requestcache_hit_count \s gauge \n
+        \# \s HELP \s opensearch_index_requestcache_hit_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_requestcache_hit_count \s gauge \n
         (
-          es_index_requestcache_hit_count\{
+          opensearch_index_requestcache_hit_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_requestcache_miss_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_requestcache_miss_count \s gauge \n
+        \# \s HELP \s opensearch_index_requestcache_miss_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_requestcache_miss_count \s gauge \n
         (
-          es_index_requestcache_miss_count\{
+          opensearch_index_requestcache_miss_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -65,10 +65,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_requestcache_evictions_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_requestcache_evictions_count \s gauge \n
+        \# \s HELP \s opensearch_index_requestcache_evictions_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_requestcache_evictions_count \s gauge \n
         (
-          es_index_requestcache_evictions_count\{
+          opensearch_index_requestcache_evictions_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_22_index_recovery.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_22_index_recovery.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_recovery_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_recovery_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_recovery_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_recovery_current_number \s gauge \n
         (
-          es_index_recovery_current_number\{
+          opensearch_index_recovery_current_number\{
               cluster="yamlRestTest",type="(source|target)",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){4}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_recovery_throttle_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_recovery_throttle_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_recovery_throttle_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_recovery_throttle_time_seconds \s gauge \n
         (
-          es_index_recovery_throttle_time_seconds\{
+          opensearch_index_recovery_throttle_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_23_index_translog.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_23_index_translog.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_translog_operations_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_translog_operations_number \s gauge \n
+        \# \s HELP \s opensearch_index_translog_operations_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_translog_operations_number \s gauge \n
         (
-          es_index_translog_operations_number\{
+          opensearch_index_translog_operations_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_translog_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_translog_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_translog_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_translog_size_bytes \s gauge \n
         (
-          es_index_translog_size_bytes\{
+          opensearch_index_translog_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_translog_uncommitted_operations_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_translog_uncommitted_operations_number \s gauge \n
+        \# \s HELP \s opensearch_index_translog_uncommitted_operations_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_translog_uncommitted_operations_number \s gauge \n
         (
-          es_index_translog_uncommitted_operations_number\{
+          opensearch_index_translog_uncommitted_operations_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -65,10 +65,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_translog_uncommitted_size_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_translog_uncommitted_size_bytes \s gauge \n
+        \# \s HELP \s opensearch_index_translog_uncommitted_size_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_translog_uncommitted_size_bytes \s gauge \n
         (
-          es_index_translog_uncommitted_size_bytes\{
+          opensearch_index_translog_uncommitted_size_bytes\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_24_index_warmer.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_24_index_warmer.yml
@@ -29,10 +29,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_warmer_current_number (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_warmer_current_number \s gauge \n
+        \# \s HELP \s opensearch_index_warmer_current_number (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_warmer_current_number \s gauge \n
         (
-          es_index_warmer_current_number\{
+          opensearch_index_warmer_current_number\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -41,10 +41,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_warmer_time_seconds (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_warmer_time_seconds \s gauge \n
+        \# \s HELP \s opensearch_index_warmer_time_seconds (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_warmer_time_seconds \s gauge \n
         (
-          es_index_warmer_time_seconds\{
+          opensearch_index_warmer_time_seconds\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
@@ -53,10 +53,10 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_index_warmer_count (\s|\w|\d)+ \n
-        \# \s TYPE \s es_index_warmer_count \s gauge \n
+        \# \s HELP \s opensearch_index_warmer_count (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_index_warmer_count \s gauge \n
         (
-          es_index_warmer_count\{
+          opensearch_index_warmer_count\{
               cluster="yamlRestTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}

--- a/src/yamlRestTest/resources/rest-api-spec/test/40_10_cluster_settings_disk_threshold.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/40_10_cluster_settings_disk_threshold.yml
@@ -20,9 +20,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
-        es_cluster_routing_allocation_disk_threshold_enabled\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_disk_threshold_enabled\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/
@@ -52,9 +52,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
-        es_cluster_routing_allocation_disk_threshold_enabled\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_disk_threshold_enabled\{
             cluster="yamlRestTest"
         \,} \s 0\.0 \n?
         .*/
@@ -84,9 +84,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
-        es_cluster_routing_allocation_disk_threshold_enabled\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_disk_threshold_enabled\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/
@@ -117,9 +117,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
-        es_cluster_routing_allocation_disk_threshold_enabled\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_disk_threshold_enabled\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/
@@ -149,9 +149,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
-        es_cluster_routing_allocation_disk_threshold_enabled\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_disk_threshold_enabled\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/
@@ -181,9 +181,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
-        es_cluster_routing_allocation_disk_threshold_enabled\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_disk_threshold_enabled\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/

--- a/src/yamlRestTest/resources/rest-api-spec/test/40_20_cluster_settings_disk_watermark_bytes.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/40_20_cluster_settings_disk_watermark_bytes.yml
@@ -25,9 +25,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_bytes \s gauge \n
-        es_cluster_routing_allocation_disk_watermark_low_bytes\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_low_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_low_bytes \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_low_bytes\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/
@@ -35,9 +35,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_bytes \s gauge \n
-        es_cluster_routing_allocation_disk_watermark_high_bytes\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_high_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_high_bytes \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_high_bytes\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/
@@ -45,9 +45,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes \s gauge \n
-        es_cluster_routing_allocation_disk_watermark_flood_stage_bytes\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_bytes \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_flood_stage_bytes\{
             cluster="yamlRestTest"
         \,} \s 1\.0 \n?
         .*/
@@ -66,24 +66,24 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_pct (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_pct \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_low_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_low_pct \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_pct (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_pct \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_high_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_high_pct \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_pct \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
@@ -114,9 +114,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_pct (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_pct \s gauge \n
-        es_cluster_routing_allocation_disk_watermark_low_pct\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_low_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_low_pct \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_low_pct\{
             cluster="yamlRestTest"
         \,} \s 99\.9 \n?
         .*/
@@ -124,9 +124,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_pct (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_pct \s gauge \n
-        es_cluster_routing_allocation_disk_watermark_high_pct\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_high_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_high_pct \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_high_pct\{
             cluster="yamlRestTest"
         \,} \s 99\.9 \n?
         .*/
@@ -134,9 +134,9 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct \s gauge \n
-        es_cluster_routing_allocation_disk_watermark_flood_stage_pct\{
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_pct \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_flood_stage_pct\{
             cluster="yamlRestTest"
         \,} \s 99\.9 \n?
         .*/
@@ -146,24 +146,24 @@
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_bytes \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_low_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_low_bytes \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_bytes \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_high_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_high_bytes \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
   - match:
       $body: |
         /.*
-        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes (\s|\w|\d)+ \n
-        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes \s gauge
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_bytes \s gauge
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 


### PR DESCRIPTION
Introducing a new setting `prometheus.metric_name.prefix` with the default value `opensearch_`.

Closes #7

Signed-off-by: lukas-vlcek <lukas.vlcek@aiven.io>